### PR TITLE
Fix compiler error between FluidNavBarStyle and Diagnosticable which has an empty constructor 

### DIFF
--- a/lib/src/fluid_nav_bar_style.dart
+++ b/lib/src/fluid_nav_bar_style.dart
@@ -19,7 +19,7 @@ import 'package:flutter/widgets.dart';
 /// ```
 /// {@end-tool}
 @immutable
-class FluidNavBarStyle extends Diagnosticable {
+class FluidNavBarStyle with Diagnosticable {
 
   /// The navigation bar background color
   final Color barBackgroundColor;

--- a/lib/src/fluid_nav_bar_style.dart
+++ b/lib/src/fluid_nav_bar_style.dart
@@ -19,7 +19,7 @@ import 'package:flutter/widgets.dart';
 /// ```
 /// {@end-tool}
 @immutable
-class FluidNavBarStyle with Diagnosticable {
+class FluidNavBarStyle with DiagnosticableMixin {
 
   /// The navigation bar background color
   final Color barBackgroundColor;


### PR DESCRIPTION
Maybe my dart version is to high so that it has this error.